### PR TITLE
Fixed type of Guid_Parsable.cs

### DIFF
--- a/src/StronglyTypedIds/Templates/Guid/Guid_Parsable.cs
+++ b/src/StronglyTypedIds/Templates/Guid/Guid_Parsable.cs
@@ -7,7 +7,7 @@
 
         public static bool TryParse(string? s, System.IFormatProvider? provider, out TESTID result)
         {
-            long res = 0;
+            Guid res = Guid.Empty;
             var ok = Guid.TryParse(s, provider, out res);
             result = new TESTID(res);
             return ok;


### PR DESCRIPTION
The variable res (used as result of TryParse) was of type long instead of type Guid